### PR TITLE
Fixed errors that crash Django

### DIFF
--- a/backend/apps/readings/analysis.py
+++ b/backend/apps/readings/analysis.py
@@ -41,7 +41,7 @@ class RereadingAnalysis:
         """
         list_of_times = []
         for row in self.responses:
-            for view_time in row.get('views'):
+            for view_time in row.get_parsed_views():
                 list_of_times.append(view_time)
         if not list_of_times:
             median_view_time = 0

--- a/backend/apps/readings/serializers.py
+++ b/backend/apps/readings/serializers.py
@@ -51,7 +51,7 @@ class StudentSerializer(serializers.ModelSerializer):
 
         fields = (
             'id',
-            'story',
+            # 'story',
             'student_responses',
         )
 


### PR DESCRIPTION
Two things were preventing Djanog from running on a local server:

- The student serializer object references story even though it is no longer in the model (it is just commented so it can potentially be referenced later)

- There was a response.get() call when it should have been `get_parsed_views`