### PR TITLE
Hook up document api to the frontend -- we can read recitatif!

### DIFF
--- a/backend/apps/readings/serializers.py
+++ b/backend/apps/readings/serializers.py
@@ -126,7 +126,6 @@ class DocumentSerializer(serializers.ModelSerializer):
     """
     Serializes Document metadata and associated segments
     """
-
     segments = SegmentSerializer(many=True, read_only=True)
 
     class Meta:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -27,9 +27,9 @@ urlpatterns = [
     path('admin/', admin.site.urls),
 
     # API endpoints
-    path('api/', readings_views.ListDocument.as_view()),
+    path('api/documents/', readings_views.ListDocument.as_view()),
     path('api/add-response/', readings_views.ListStudent.as_view()),
-    path('api/<int:pk>/', readings_views.DetailDocument.as_view()),
+    path('api/documents/<int:pk>/', readings_views.DetailDocument.as_view()),
     path('api/analysis/', readings_views.analysis),
 
     # Prototyping API endpoints

--- a/docs/document_prototype.txt
+++ b/docs/document_prototype.txt
@@ -1,0 +1,65 @@
+This was the data format for the document in the frontend that Jason and Ophelia originally designed.
+
+Keep it! There's some stuff we haven't implemented here yet.
+
+- RA (2019-10-25)
+
+// This is a document object hardcoded here for prototyping,
+// to be replaced with an object fetched via API call once that's ready
+const document_prototype = {
+    title: "The Pigs",
+    prompts: ["the author is alive", "the book was written during the cold war"],
+    segments: [
+        {
+            text: "The little pig built a house.",
+            seq: 0,
+            prompts: ["this is an ad"],
+            questions: [
+                {
+                    question: "question_test",
+                    is_free_response: true,
+                    choices: [],
+                },
+                {
+                    question: "question_test2",
+                    is_free_response: false,
+                    choices: ["yes", "no"],
+                },
+            ]
+        },
+        {
+            text: "The wolf huffed and puffed",
+            seq: 1,
+            prompts: ["this is a story", "the author is testing you"],
+            questions: [
+                {
+                    question: "question_test",
+                    is_free_response: true,
+                    choices: [],
+                },
+                {
+                    question: "question_test2",
+                    is_free_response: false,
+                    choices: ["yes", "no"],
+                },
+            ]
+        },
+        {
+            text: "The pigs have brick house so they are safe.",
+            seq: 2,
+            prompts: ["this is a poem"],
+            questions: [
+                {
+                    question: "question_test",
+                    is_free_response: true,
+                    choices: [],
+                },
+                {
+                    question: "question_test2",
+                    is_free_response: false,
+                    choices: ["yes", "no"],
+                },
+            ]
+        },
+    ]
+};

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -1,96 +1,57 @@
 import React from "react";
 // import PropTypes from 'prop-types';
 
-// This is a document object hardcoded here for prototyping,
-// to be replaced with an object fetched via API call once that's ready
-const document = {
-    title: "The Pigs",
-    prompts: ["the author is alive", "the book was written during the cold war"],
-    segments: [
-        {
-            text: "The little pig built a house.",
-            seq: 0,
-            prompts: ["this is an ad"],
-            questions: [
-                {
-                    question: "question_test",
-                    is_free_response: true,
-                    choices: [],
-                },
-                {
-                    question: "question_test2",
-                    is_free_response: false,
-                    choices: ["yes", "no"],
-                },
-            ]
-        },
-        {
-            text: "The wolf huffed and puffed",
-            seq: 1,
-            prompts: ["this is a story", "the author is testing you"],
-            questions: [
-                {
-                    question: "question_test",
-                    is_free_response: true,
-                    choices: [],
-                },
-                {
-                    question: "question_test2",
-                    is_free_response: false,
-                    choices: ["yes", "no"],
-                },
-            ]
-        },
-        {
-            text: "The pigs have brick house so they are safe.",
-            seq: 2,
-            prompts: ["this is a poem"],
-            questions: [
-                {
-                    question: "question_test",
-                    is_free_response: true,
-                    choices: [],
-                },
-                {
-                    question: "question_test2",
-                    is_free_response: false,
-                    choices: ["yes", "no"],
-                },
-            ]
-        },
-    ]
-};
-
-
 
 class ReadingView extends React.Component {
     constructor(props){
         super(props);
         this.state = {
             segmentNum: 0,
+            document: null,
         }
+    }
+
+    async componentDidMount() {
+        try {
+            // Hardcode the document we know exists for now,
+            // Generalize later...
+            const response = await fetch('/api/documents/1');
+            const document = await response.json();
+            this.setState({document});
+        } catch (e) {
+            console.log(e);
+        }
+
     }
 
     changeSegment (changeNum) {
         const newNum = this.state.segmentNum + changeNum;
         // document will be replaced by actual data
-        if (newNum >= 0 && newNum < document.segments.length){
+        if (newNum >= 0 && newNum < this.state.document.segments.length){
             this.setState({segmentNum: newNum});
         }
     }
 
     render() {
-        const data = document;
-        return (
-            <div className={"container"}>
-                <h1>{data.title}</h1>
-                <p><b>Prompts: </b>{data.prompts.map(el => "[" + el + "] ")}</p>
-                <p>Segment Number: {this.state.segmentNum + 1}</p>
-                <p>{data.segments[this.state.segmentNum].text}</p>
-                <button onClick = {() => this.changeSegment(-1)}>Back</button>
-                <button onClick = {() => this.changeSegment(1)}>Next</button>
-            </div>
-        );
+        // We're going to use this code for prompts, but right now
+        // we're not actually getting them from the API!
+        // <p><b>Prompts: </b>{data.prompts.map(el => "[" + el + "] ")}</p>
+        const data = this.state.document;
+        if (data) {
+            return (
+                <div className={"container"}>
+                    <h1>{data.title}</h1>
+                    <p>Segment Number: {this.state.segmentNum + 1}</p>
+                    <p>{data.segments[this.state.segmentNum].text}</p>
+                    <button onClick={() => this.changeSegment(-1)}>Back</button>
+                    <button onClick={() => this.changeSegment(1)}>Next</button>
+                </div>
+            );
+        } else {
+            return (
+                <div>Loading!</div>
+            );
+        }
     }
 }
 


### PR DESCRIPTION
thanks @samimak37 for doing the groundwork that made this EZ PZ.

- Hooks up the reading_view frontend to the document serializer
- Move the prototyping document object to a documentation folder -- there are still some bits that we need to implement from that design (e.g., prompts and contexts per segment)
- Changed URL of document api endpoint to `api/documents/<int:pk>/` and `api/documents/` to make it a little clearer