### PR TITLE
Fixed back button, added questions and contexts

### DIFF
--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -78,13 +78,20 @@ class ReadingView extends React.Component {
 
                         {this.state.rereading &&
                             <div className={"analysis col-4"}>
-                                <p><b>Contexts: </b></p>
+                                <p><b>Context: </b></p>
                                 <p>
-                                    {segment_contexts.map(el => el.text)}
+                                    {segment_contexts.map((el,i) =>
+                                        <ul key={i}>
+                                            <li>{el.text}</li>
+                                        </ul>)}
                                 </p>
                                 <p><b>Questions: </b></p>
                                 <p>
-                                    {segment_questions.map(el => el.text)}
+                                    {segment_questions.map((el,i) =>
+                                        <ul key={i}>
+                                            <li>{el.text}</li>
+                                        </ul>
+                                    )}
                                 </p>
                                 <p>
                                     <b>Add an annotation: </b><input

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -1,23 +1,6 @@
 import React from "react";
 // import PropTypes from 'prop-types';
 
-// THIS IS JUST FOR PROTOTYPING
-// DELETE ME as soon as these data are included in the API endpoint
-const PROMPTS_PROTOTYPE = ["this is an ad"];
-const QUESTIONS_PROTOTYPE = [
-    {
-        question: "question_test",
-        is_free_response: true,
-        choices: [],
-    },
-    {
-        question: "question_test2",
-        is_free_response: false,
-        choices: ["yes", "no"],
-    },
-];
-
-
 class ReadingView extends React.Component {
     constructor(props){
         super(props);
@@ -44,7 +27,7 @@ class ReadingView extends React.Component {
     prevSegment () {
         // document will be replaced by actual data
         if (this.state.segmentNum > 0){
-            this.setState({segmentNum: this.state.segmentNum-1});
+            this.setState({segmentNum: this.state.segmentNum-1, rereading: true});
         }
     }
 
@@ -66,17 +49,19 @@ class ReadingView extends React.Component {
         const data = this.state.document;
 
         if (data) {
-            const questions = QUESTIONS_PROTOTYPE; // replace me with this.state.document.whatever
-            const prompts = PROMPTS_PROTOTYPE; // replace me with this.state.document.whatever
-            const segment = data.segments[this.state.segmentNum].text;
+            const current_segment = data.segments[this.state.segmentNum];
+            const segment_text = current_segment.text;
+            const segment_questions = current_segment.questions;
+            const segment_contexts = current_segment.contexts;
+            //add document_questions for questions that remain on screen for the every segment
 
             return (
                 <div className={"container"}>
                     <h1 className={"display-4 py-3 pr-3"}>{data.title}</h1>
                     <div className={"row"}>
-                        <div className={"col-9"}>
+                        <div className={"col-8"}>
                             <p>Segment Number: {this.state.segmentNum + 1}</p>
-                            <p>{segment}</p>
+                            <p>{segment_text}</p>
                             <button
                                 className={"btn btn-outline-dark mr-2"}
                                 onClick = {() => this.prevSegment()}
@@ -92,16 +77,22 @@ class ReadingView extends React.Component {
                         </div>
 
                         {this.state.rereading &&
-                            <div className={"analysis col-3"}>
-                                <p><b>Prompts: </b>{prompts.map(el => "[" + el + "] ")}</p>
-                                <p><b>Questions: </b>
-                                    {questions.map(el => "[" + el.question + "] ")}
+                            <div className={"analysis col-4"}>
+                                <p><b>Contexts: </b></p>
+                                <p>
+                                    {segment_contexts.map(el => el.text)}
                                 </p>
-                                <p><b>Add an annotation: </b><input
-                                    type="text"
-                                    value={this.state.value}
-                                    onChange={this.handleChange}
-                                /><button>Submit</button></p>
+                                <p><b>Questions: </b></p>
+                                <p>
+                                    {segment_questions.map(el => el.text)}
+                                </p>
+                                <p>
+                                    <b>Add an annotation: </b><input
+                                        type="text"
+                                        value={this.state.value}
+                                        onChange={this.handleChange}
+                                    /><button>Submit</button>
+                                </p>
                             </div>
                         }
                     </div>

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -54,7 +54,7 @@ class ReadingView extends React.Component {
             const segment_lines = segment_text.split("\r\n");
             const segment_questions = current_segment.questions;
             const segment_contexts = current_segment.contexts;
-            // TODO: add document_questions for questions that remain on screen for the every segment
+
             return (
                 <div className={"container"}>
                     <h1 className={"display-4 py-3 pr-3"}>{data.title}</h1>


### PR DESCRIPTION
Annotations aren't working yet, but fixed the issue where pressing the back button brings the reader back to the cold-read mode instead of rereading mode (mentioned in issue #64). Also added the questions and contexts from the API and put them in a list so it's easier to see multiple contexts/questions, and changed some variable names to make it more readable and accommodate full-document questions.