### PR TITLE
Changed serializer wording to enable doc questions

### DIFF
--- a/backend/apps/readings/serializers.py
+++ b/backend/apps/readings/serializers.py
@@ -154,7 +154,7 @@ class DocumentSerializer(serializers.ModelSerializer):
     Serializes Document metadata and associated segments
     """
     segments = SegmentSerializer(many=True, read_only=True)
-    document_questions = DocumentQuestionSerializer(many=True, read_only=True)
+    questions = DocumentQuestionSerializer(many=True, read_only=True)
 
     class Meta:
         model = Document
@@ -163,7 +163,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             'id',
             'title',
             'author',
-            'document_questions',
+            'questions',
             'segments',
         )
 


### PR DESCRIPTION
The name of the document-level questions was different between the Django model and the serializer, which prevented them from being accessible to the API. The names have been unified and it now works as expected.