### PR TITLE
Reading View: Back and Next button fixes

### DIFF
--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -65,7 +65,7 @@ class ReadingView extends React.Component {
 
     prevSegment () {
         this.updateData(false);
-        this.setState({segment_num: this.state.segment_num-1});
+        this.setState({rereading: false, segment_num: this.state.segment_num-1});
         window.scrollTo(0,0);
     }
 

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -20,7 +20,6 @@ Segment.propTypes = {
     segment_num: PropTypes.number,
 };
 
-
 class ReadingView extends React.Component {
     constructor(props){
         super(props);
@@ -29,6 +28,7 @@ class ReadingView extends React.Component {
             timer: null,
             segment_data: [],
             segments_viewed: [0],
+            jump_to_value: null,
             scrollTop: 0,
             scroll_ups: 0,
             scrolling_up: false,
@@ -89,9 +89,17 @@ class ReadingView extends React.Component {
         //The segment number is pushed regardless of whether or not the user has read the page
         // before so that page reread order can also be determined.
         segments_viewed.push(segmentNum);
-        console.log(segments_viewed);
-        this.setState({rereading, segments_viewed, segment_num : segmentNum});
+        this.setState({rereading, segments_viewed, segment_num: segmentNum});
     }
+
+    handleJumpToFieldChange = (e) => {
+        let numericValue = parseInt(e.target.value) - 1;
+        this.setState({jump_to_value: numericValue});
+    };
+
+    handleJumpToButton = () => {
+        this.gotoSegment(this.state.jump_to_value);
+    };
 
     async componentDidMount() {
         try {
@@ -147,6 +155,22 @@ class ReadingView extends React.Component {
                                 this.state.segment_num >= doc.segments.length - 1}
                             >
                                 {this.state.rereading ? 'Next' : 'Reread'}
+                            </button>
+                        </div>
+
+                        <div className={'col-4'}>
+                            <input
+                                type="text"
+                                onChange={this.handleJumpToFieldChange}
+                            />
+                            <button
+                                className={"btn btn-outline-dark"}
+                                onClick={this.handleJumpToButton}
+                                //Checks isNaN so that an empty string doesn't count as 0
+                                disabled={Number.isNaN(this.state.jump_to_value) ||
+                                    !this.state.segments_viewed.includes(this.state.jump_to_value)}
+                            >
+                                Jump to
                             </button>
                         </div>
 

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -124,12 +124,15 @@ class ReadingView extends React.Component {
                             <button
                                 className={"btn btn-outline-dark mr-2"}
                                 onClick={() => this.prevSegment()}
+                                disabled={this.state.segment_num === 0}
                             >
                                 Back
                             </button>
                             <button
                                 className={"btn btn-outline-dark"}
                                 onClick={() => this.nextSegment()}
+                                disabled={this.state.rereading &&
+                                this.state.segment_num >= doc.segments.length - 1}
                             >
                                 {this.state.rereading ? 'Next' : 'Reread'}
                             </button>

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -28,6 +28,7 @@ class ReadingView extends React.Component {
             segment_num: 0,
             timer: null,
             segment_data: [],
+            segments_viewed: [0],
             scrollTop: 0,
             scroll_ups: 0,
             scrolling_up: false,
@@ -64,8 +65,8 @@ class ReadingView extends React.Component {
     };
 
     prevSegment () {
+        this.gotoSegment(this.state.segment_num - 1);
         this.updateData(false);
-        this.setState({rereading: false, segment_num: this.state.segment_num-1});
         window.scrollTo(0,0);
     }
 
@@ -73,12 +74,23 @@ class ReadingView extends React.Component {
         this.updateData(false);
         if (this.state.rereading) {
             // If we're already rereading, move to the next segment
-            this.setState({rereading: false, segment_num: this.state.segment_num+1});
+            this.gotoSegment(this.state.segment_num + 1);
         } else {
             // Otherwise, move on to the rereading layout
             this.setState({rereading: true});
         }
         window.scrollTo(0,0);
+    }
+
+    gotoSegment(segmentNum) {
+        const segments_viewed = this.state.segments_viewed.slice();
+        let rereading = segments_viewed.includes(segmentNum);
+
+        //The segment number is pushed regardless of whether or not the user has read the page
+        // before so that page reread order can also be determined.
+        segments_viewed.push(segmentNum);
+        console.log(segments_viewed);
+        this.setState({rereading, segments_viewed, segment_num : segmentNum});
     }
 
     async componentDidMount() {

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -140,7 +140,9 @@ class ReadingView extends React.Component {
                             segmentLines={segment_lines}
                             segment_num={this.state.segment_num}
                         />
-                        <div className={'col-8'}>
+                    </div>
+                    <div className={"row"}>
+                        <div className={'col-2'}>
                             <button
                                 className={"btn btn-outline-dark mr-2"}
                                 onClick={() => this.prevSegment()}
@@ -158,24 +160,26 @@ class ReadingView extends React.Component {
                             </button>
                         </div>
 
-                        <div className={'col-4'}>
+                        <div className={"col-3 input-group"}>
                             <input
+                                className={"form-control"}
                                 type="text"
                                 onChange={this.handleJumpToFieldChange}
                             />
                             <button
-                                className={"btn btn-outline-dark"}
+                                className={"btn btn-outline-dark form-control"}
                                 onClick={this.handleJumpToButton}
                                 //Checks isNaN so that an empty string doesn't count as 0
                                 disabled={Number.isNaN(this.state.jump_to_value) ||
-                                    !this.state.segments_viewed.includes(this.state.jump_to_value)}
+                                    !this.state.segments_viewed.includes(
+                                        this.state.jump_to_value)}
                             >
-                                Jump to
+                            Jump
                             </button>
                         </div>
 
                         {this.state.rereading &&
-                            <div className={"analysis col-4"}>
+                            <div className={"analysis col-7"}>
                                 <p><b>Context: </b></p>
                                 {segment_contexts.map((el,i) =>
                                     <ul key={i}>


### PR DESCRIPTION
The back and next buttons are now disabled on the first and last segments respectively. However, the "Reread" button is still active on the last segment.

![Disabled Next Button](https://user-images.githubusercontent.com/34782089/68417532-96685a00-0164-11ea-8114-acbca79d0ae1.PNG)
![Not Disabled Reread Button](https://user-images.githubusercontent.com/34782089/68417533-96685a00-0164-11ea-9ca7-4e3fcbc1118b.PNG)
![Disabled Back Button](https://user-images.githubusercontent.com/34782089/68417534-96685a00-0164-11ea-95f4-119bad47a819.PNG)

I also fixed a bug with the back button where the "rereading" state was never toggled. "rereading" is now set to false every time the back button is pressed.