### PR TITLE
Added jump button, revisiting pages enters rereading view

### DIFF
--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -74,6 +74,8 @@ class ReadingView extends React.Component {
             timer: null,
             scroll_top: 0,
             scroll_data: [],
+            segments_viewed: [0],
+            jump_to_value: null,
             rereading: false,  // we alternate reading and rereading
             document: null,
             interval_timer: null,
@@ -175,38 +177,45 @@ class ReadingView extends React.Component {
 
     prevSegment () {
         this.sendData(false);
-        if (this.state.segment_num > 0) {
-            this.setState({
-                segment_num: this.state.segment_num - 1,
-                rereading: true,
-                segmentQuestionNum: 0,
-                segmentContextNum: 0,
-            });
-        }
+        this.gotoSegment(this.state.segment_num - 1);
         this.segment_ref.current.scrollTo(0,0);
     }
 
     nextSegment () {
         this.sendData(false);
-        const length = this.state.document.segments.length;
-        const current_segment = this.state.segment_num;
-        if (current_segment < length){
-            if (this.state.rereading) {
-                // If we're already rereading, move to the next segment
-                this.setState({
-                    rereading: false,
-                    segment_num: this.state.segment_num + 1,
-                    segmentQuestionNum: 0,
-                    segmentContextNum: 0,
-                    segmentResponseArray: [],
-                });
-            } else {
-                // Otherwise, move on to the rereading layout
-                this.setState({rereading: true});
-            }
+
+        if (this.state.rereading) {
+            // If we're already rereading, move to the next segment
+            this.gotoSegment(this.state.segment_num + 1);
+            this.setState({segmentResponseArray: []})
+            //TODO Figure out if this can be integrated into gotoSegment. I wasn't exactly
+            // sure why it was being set here but not prevSegment().
+        } else {
+            // Otherwise, move on to the rereading layout
+            this.setState({rereading: true});
         }
 
         this.segment_ref.current.scrollTo(0,0);
+    }
+
+    gotoSegment(segmentNum) {
+        console.log(segmentNum);
+        let segmentCount = this.state.document.segments.length;
+        if (segmentNum >= 0 && segmentNum < segmentCount) {
+            const segments_viewed = this.state.segments_viewed.slice();
+            let rereading = segments_viewed.includes(segmentNum);
+
+            //The segment number is pushed regardless of whether or not the user has read the page
+            // before so that page reread order can also be determined.
+            segments_viewed.push(segmentNum);
+            this.setState({
+                rereading,
+                segments_viewed,
+                segment_num: segmentNum,
+                segmentQuestionNum: 0,
+                segmentContextNum: 0,
+            });
+        }
     }
 
     toOverview () {

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -218,6 +218,15 @@ class ReadingView extends React.Component {
         }
     }
 
+    handleJumpToFieldChange = (e) => {
+        let numericValue = parseInt(e.target.value) - 1;
+        this.setState({jump_to_value: numericValue});
+    };
+
+    handleJumpToButton = () => {
+        this.gotoSegment(this.state.jump_to_value);
+    };
+
     toOverview () {
         this.setState({overview: true})
     }
@@ -310,10 +319,27 @@ class ReadingView extends React.Component {
                                     To Overview
                                 </button>
                             }
+                            <div className={"input-group"}>
+                                <input
+                                    className={"form-control"}
+                                    type="text"
+                                    onChange={this.handleJumpToFieldChange}
+                                />
+                                <button
+                                    className={"btn btn-outline-dark form-control"}
+                                    onClick={this.handleJumpToButton}
+                                    //Checks isNaN so that an empty string doesn't count as 0
+                                    disabled={Number.isNaN(this.state.jump_to_value) ||
+                                        !this.state.segments_viewed.includes(
+                                            this.state.jump_to_value)}
+                                >
+                                Jump
+                                </button>
+                            </div>
                         </div>
 
                         {this.state.rereading &&
-                            <div className={"analysis col-4"}>
+                            <div className={"analysis col-3"}>
                                 {segment_response_fields}
 
                                 {document_questions && (

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -124,7 +124,6 @@ class ReadingView extends React.Component {
                     is_rereading: this.state.rereading,
                 }],
             };
-            console.log(JSON.stringify(reading_data));
             fetch(url, {
                 method: 'POST',
                 body: JSON.stringify(reading_data),
@@ -199,7 +198,6 @@ class ReadingView extends React.Component {
     }
 
     gotoSegment(segmentNum) {
-        console.log(segmentNum);
         let segmentCount = this.state.document.segments.length;
         if (segmentNum >= 0 && segmentNum < segmentCount) {
             const segments_viewed = this.state.segments_viewed.slice();
@@ -289,40 +287,64 @@ class ReadingView extends React.Component {
                         document_questions={document_questions}
                     />
                     :
-                    <div className={"row"}>
-                        <div className={'col-8'}>
-                            <p>Segment Number: {this.state.segment_num + 1}</p>
-                            <Segment
-                                text={current_segment.text}
-                                handleScroll={(e) => this.handleScroll(e)}
-                                segment_ref={this.segment_ref}
-                            />
-                            {this.state.segment_num > 0 &&
-                            <button
-                                className={"btn btn-outline-dark mr-2"}
-                                onClick={() => this.prevSegment()}
-                            >
-                                Back
-                            </button>
+                    <React.Fragment>
+                        <div className={"row"}>
+                            <div className={'col-8'}>
+                                <p>Segment Number: {this.state.segment_num + 1}</p>
+                                <Segment
+                                    text={current_segment.text}
+                                    handleScroll={(e) => this.handleScroll(e)}
+                                    segment_ref={this.segment_ref}
+                                />
+                            </div>
+
+                            {this.state.rereading &&
+                                <div className={"analysis col-4"}>
+                                    {segment_response_fields}
+
+                                    {document_questions && (
+                                        <div>
+                                            <p><b>Document Questions: </b></p>
+                                            {document_questions.map((el,i) =>
+                                                <p key={i}>
+                                                    {el.is_overview_question ? null : el.text}
+                                                </p>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
                             }
-                            {this.state.segment_num < doc.segments.length - 1 ?
+                        </div>
+                        <div className={"row"}>
+                            <div className={"col-4"}>
+                                {this.state.segment_num > 0 &&
                                 <button
-                                    className={"btn btn-outline-dark"}
-                                    onClick={() => this.nextSegment()}
+                                    className={"btn btn-outline-dark mr-2"}
+                                    onClick={() => this.prevSegment()}
                                 >
-                                    {this.state.rereading ? 'Next' : 'Reread'}
-                                </button> :
-                                <button
-                                    className={"btn btn-outline-dark"}
-                                    onClick={() => this.toOverview()}
-                                >
-                                    To Overview
+                                    Back
                                 </button>
-                            }
-                            <div className={"input-group"}>
+                                }
+                                {this.state.segment_num < doc.segments.length - 1 ?
+                                    <button
+                                        className={"btn btn-outline-dark"}
+                                        onClick={() => this.nextSegment()}
+                                    >
+                                        {this.state.rereading ? 'Next' : 'Reread'}
+                                    </button> :
+                                    <button
+                                        className={"btn btn-outline-dark"}
+                                        onClick={() => this.toOverview()}
+                                    >
+                                        To Overview
+                                    </button>
+                                }
+                            </div>
+                            <div className={"col-4 input-group"}>
                                 <input
                                     className={"form-control"}
                                     type="text"
+                                    placeholder={"Page #"}
                                     onChange={this.handleJumpToFieldChange}
                                 />
                                 <button
@@ -337,24 +359,7 @@ class ReadingView extends React.Component {
                                 </button>
                             </div>
                         </div>
-
-                        {this.state.rereading &&
-                            <div className={"analysis col-3"}>
-                                {segment_response_fields}
-
-                                {document_questions && (
-                                    <div>
-                                        <p><b>Document Questions: </b></p>
-                                        {document_questions.map((el,i) =>
-                                            <p key={i}>
-                                                {el.is_overview_question ? null : el.text}
-                                            </p>
-                                        )}
-                                    </div>
-                                )}
-                            </div>
-                        }
-                    </div>
+                    </React.Fragment>
                 }
             </div>
         );


### PR DESCRIPTION
The "Jump" button has been added. It allows users to quickly go to previously seen segments.

Functionality can be seen here:
https://gyazo.com/e702e5fb981952d4a8061367f84e1fbd
(Note the input says "Page #," but I changed it to "Segment #" in the latest commit.

The button is disabled unless that segment has already been viewed.

Additional bug fix:
When revisiting a page, the rereading view will immediately be opened and the "Next" button and segment questions will appear.