### PR TITLE
Prevent empty responses and repopulate previous answers

### DIFF
--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -402,9 +402,7 @@ export class ReadingView extends React.Component {
     }
 
     nextSegment () {
-        console.log(this.state.rereading);
         if (this.state.rereading && !this.allowSegmentChange()) {return;}
-        console.log("went through");
         this.sendData(false);
 
         if (this.state.rereading) {
@@ -459,8 +457,14 @@ export class ReadingView extends React.Component {
     }
 
     buildQuestionFields(questions, is_document_question) {
-        return questions.map((question, id) => (
-            <React.Fragment key={id}>
+        return questions.map((question, id) => {
+            const responseArray = is_document_question ?
+                this.state.documentResponseArray :
+                this.state.segmentResponseArray;
+            const currentTexts = responseArray.filter(
+                response => response.id === question.id
+            );
+            return (<React.Fragment key={id}>
                 <div className="mb-5">
                     <div className='segment-question-text question-text'>
                         {question.text}
@@ -469,6 +473,7 @@ export class ReadingView extends React.Component {
                         className='form-control form-control-lg questions-boxes'
                         id="exampleFormControlTextarea1"
                         rows="4"
+                        value={currentTexts.length !== 0 ? currentTexts[0].response : ""}
                         onChange={
                             is_document_question
                                 ? this.handleDocumentResponseChange.bind(this, question.id)
@@ -477,7 +482,7 @@ export class ReadingView extends React.Component {
                     />
                 </div>
             </React.Fragment>
-        ));
+            )});
     }
 
     handleStudentName(e) {

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -218,6 +218,7 @@ export class ReadingView extends React.Component {
             segmentQuestionNum: 0,
             segmentResponseArray: [],
             documentResponseArray: [],
+            previousSegmentResponses: {},
         };
         this.csrftoken = getCookie('csrftoken');
 
@@ -408,7 +409,6 @@ export class ReadingView extends React.Component {
         if (this.state.rereading) {
             // If we're already rereading, move to the next segment
             this.gotoSegment(this.state.segment_num + 1);
-            this.setState({segmentResponseArray: []})
             //TODO Figure out if this can be integrated into gotoSegment. I wasn't exactly
             // sure why it was being set here but not prevSegment().
         } else {
@@ -424,15 +424,22 @@ export class ReadingView extends React.Component {
         if (segmentNum >= 0 && segmentNum < segmentCount) {
             const segments_viewed = this.state.segments_viewed.slice();
             let rereading = segments_viewed.includes(segmentNum);
-
             //The segment number is pushed regardless of whether or not the user has read the page
             // before so that page reread order can also be determined.
             segments_viewed.push(segmentNum);
+            // Store the current segment reading data into state
+            const previousSegmentResponses = this.state.previousSegmentResponses;
+            previousSegmentResponses[this.state.segment_num] = this.state.segmentResponseArray;
+            const segmentResponseArray = segmentNum in previousSegmentResponses ?
+                previousSegmentResponses[segmentNum] : [];
+
             this.setState({
                 rereading,
                 segments_viewed,
                 segment_num: segmentNum,
                 segmentQuestionNum: 0,
+                segmentResponseArray,
+                previousSegmentResponses,
             });
         }
     }


### PR DESCRIPTION
Users must enter a name in order to start reading.
Users must answer every question in order to move on to the segments that the user wants to go to.
Repopulate document questions for every segment.
Repopulate segment questions when the user is going back to previous segments.
Fixes #79 