### PR TITLE
Responsive design tweaks

### DIFF
--- a/frontend/src/styles/overview_view.scss
+++ b/frontend/src/styles/overview_view.scss
@@ -8,11 +8,6 @@ p, ul, ol {
     padding: 5px 20% 5px 20%;
 }
 
-h1, h3 {
-    padding-left: 20%;
-    padding-right: 20%;
-}
-
 li:not(:last-child) {
     margin-bottom: 5px;
 }

--- a/frontend/src/styles/reading_view.scss
+++ b/frontend/src/styles/reading_view.scss
@@ -1,3 +1,7 @@
+.author {
+    font-size: 50%;
+}
+
 
 /*
  * Scrollbar -- show always, and style it
@@ -13,6 +17,13 @@
     -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
 
+
+.segment-container {
+    @extend .col;
+    @extend .col-lg-8;
+    max-width: 600px;
+}
+
 .segment,
 .scroll-overview {
     height: 500px;
@@ -22,6 +33,7 @@
     font-size: 18pt;
 }
 .segment-num {
+    @extend .mb-0;
     font-weight: bold;
 }
 
@@ -30,6 +42,20 @@
     font-family: Perpetua;
 }
 
+.questions-container {
+    @extend .col;
+    @extend .col-lg-4;
+    @extend .pl-lg-5;
+    height: 500px;
+    overflow: auto;
+
+    @extend .mt-3;
+    @extend .mt-lg-0;
+    @media (min-width: 1140px) {
+        max-width: 600px;
+        min-width: 500px;
+    }
+}
 
 .questions-boxes {
     overflow: auto;
@@ -66,19 +92,10 @@
   padding: 10px 0;
 }
 
-.questions-overview {
-    height: 520px;
-    overflow: auto;
-}
 
 .question-text {
     font-family: Perpetua;
     font-size: 14pt;
-}
-
-#nav_panel {
-    width: 500px;
-    margin: 0em 0em 0em 8.75em;
 }
 
 #instructions-list {
@@ -87,4 +104,15 @@
 #instructions-overview {
     padding: 0 0 0 0;
     margin-bottom: 2em;
+}
+
+
+/*
+ *  Navbar styles
+ */
+
+.next-btn {
+    @extend .btn;
+    @extend .btn-outline-dark;
+    @extend .float-right;
 }

--- a/frontend/src/views/reading_view.js
+++ b/frontend/src/views/reading_view.js
@@ -22,7 +22,7 @@ class Segment extends React.Component {
         const segment_lines = this.props.text.split("\r\n");
         return (
             <div
-                className="segment my-3"
+                className="segment"
                 ref={this.props.segment_ref}
                 onScroll={this.props.handleScroll}
                 onMouseUp={this.props.handleSelectionDragEnd}
@@ -133,52 +133,34 @@ class NavBar extends React.Component {
             && this.props.rereading;
 
         return (
-            <div className={"col-7 mx-0"} id="nav_panel">
-                <div className="row">
-                    <div className="col-2">
-                        {this.props.segment_num > 0 &&
-                        <button
-                            className="btn btn-outline-dark"
-                            onClick={() => this.props.prevSegment()}
-                        >
-                            Back
-                        </button>
-                        }
-                    </div>
-                    <div className="col-6 input-group">
-                        <input
-                            className="form-control "
-                            type="text"
-                            placeholder="Page #"
-                            onChange={this.props.handleJumpToFieldChange}
-                            onKeyDown={this.props.handleJumpToFieldKeyDown}
-                        />
-                        <button
-                            className="btn btn-outline-dark form-control"
-                            onClick={this.props.handleJumpToButton}
-                            // Checks isNaN so that an empty string
-                            // doesn't count as 0
-                            disabled={!this.props.userCanJump()}
-                        >
-                            Jump
-                        </button>
-                    </div>
-                    <div className="col-4">
-                        {!on_last_segment_and_rereading
-                            ? <button
-                                className="btn btn-outline-dark"
+            <div className="row">
+                <div className="col">
+                    {this.props.segment_num > 0 &&
+                    <button
+                        className="btn btn-outline-dark"
+                        onClick={() => this.props.prevSegment()}
+                    >
+                        Back
+                    </button>
+                    }
+                    {!on_last_segment_and_rereading
+                        ? (
+                            <button
+                                className="next-btn"
                                 onClick={() => this.props.nextSegment()}
                             >
                                 {this.props.rereading ? 'Next' : 'Reread'}
                             </button>
-                            : <button
-                                className="btn btn-outline-dark"
+                        )
+                        : (
+                            <button
+                                className="next-btn"
                                 onClick={() => this.props.toOverview()}
                             >
                                 To Overview
                             </button>
-                        }
-                    </div>
+                        )
+                    }
                 </div>
             </div>
         )
@@ -217,7 +199,7 @@ class OverviewView extends React.Component {
                         ))}
                     </div>
                 </div>
-                <div className="col-4 questions-overview">
+                <div className="col-4 questions-container">
                     <p><b>Document Questions</b></p>
                     {document_response_fields}
                     <p><b>Overview Questions</b></p>
@@ -718,8 +700,12 @@ export class ReadingView extends React.Component {
         const roman_numeral = { 1: "I", 2:"II", 3:"III", 4:"IV", 5:"V", 6:"VI", 7:"VII"};
 
         return (
-            <div className="container">
-                <h1 className="display-4 px-0 pt-4 pb-3">{doc.title}</h1>
+            <div className="container py-5">
+                <div className="row mb-4"><div className="col">
+                    <h1 className="display-4">
+                        {doc.title} <span className="author">by {doc.author}</span>
+                    </h1>
+                </div></div>
 
                 {this.state.current_view === VIEWS.OVERVIEW &&
                     <OverviewView
@@ -732,10 +718,13 @@ export class ReadingView extends React.Component {
                 {this.state.current_view === VIEWS.READING &&
                     <React.Fragment>
                         <div className="row">
-                            <p className={"segment-num ml-6 mb-0"}>
-                                Segment {roman_numeral[this.state.segment_num + 1]}
-                            </p>
-                            <div className='col-7'>
+                            <div className="col-12">
+                                <h5 className="segment-num">
+                                    Segment {roman_numeral[this.state.segment_num + 1]}
+                                </h5>
+                                <hr/>
+                            </div>
+                            <div className='segment-container'>
                                 <Segment
                                     text={current_segment.text}
                                     handleScroll={(e) => this.handleScroll(e)}
@@ -744,26 +733,22 @@ export class ReadingView extends React.Component {
                                 />
                             </div>
 
-                            {this.state.rereading &&
-                                <div className="col-5 questions-overview">
-                                    {segment_response_fields}
-                                    {document_response_fields}
-                                </div>
-                            }
-                        </div>
-                        <div className={"row"}>
-                            <NavBar
-                                document_segments={doc.segments}
-                                segment_num={this.state.segment_num}
-                                rereading={this.state.rereading}
-                                prevSegment={this.prevSegment}
-                                nextSegment={this.nextSegment}
-                                toOverview={this.toOverview}
-                                handleJumpToFieldChange={this.handleJumpToFieldChange}
-                                handleJumpToButton={this.handleJumpToButton}
-                                handleJumpToFieldKeyDown={this.handleJumpToFieldKeyDown}
-                                userCanJump={this.userCanJump}
-                            />
+                            <div className="questions-container">
+                                {this.state.rereading && segment_response_fields}
+                                {this.state.rereading && document_response_fields}
+                                <NavBar
+                                    document_segments={doc.segments}
+                                    segment_num={this.state.segment_num}
+                                    rereading={this.state.rereading}
+                                    prevSegment={this.prevSegment}
+                                    nextSegment={this.nextSegment}
+                                    toOverview={this.toOverview}
+                                    handleJumpToFieldChange={this.handleJumpToFieldChange}
+                                    handleJumpToButton={this.handleJumpToButton}
+                                    handleJumpToFieldKeyDown={this.handleJumpToFieldKeyDown}
+                                    userCanJump={this.userCanJump}
+                                />
+                            </div>
                         </div>
                     </React.Fragment>
                 }


### PR DESCRIPTION
Fixes #137 

Various design tweaks for usability, but also particularly so that the site is at least usable (if not very good) on smaller devices.
Also:
- moves navbar under the questions -- we don't allow users to hit "next" until the questions are all answered, so why have it available until then?
- removes "Jump to Page" feature (sorry @Dylan-Weber) -- keeping the infrastructure so that derivative work can use it, but we've only got 5 segments, so Sandy didn't think it was necessary

<img width="1021" alt="tweaks" src="https://user-images.githubusercontent.com/691117/69579497-9956ad80-0fa0-11ea-8658-52bb31d91c3f.png">
