### PR TITLE
Remove jumping, make evidence truly optional

### DIFF
--- a/backend/apps/readings/models.py
+++ b/backend/apps/readings/models.py
@@ -89,9 +89,6 @@ class Question(models.Model):
     response_word_limit = models.IntegerField(default=0, null=True)
     require_evidence = models.BooleanField(default=False)
 
-    def __str__(self):
-        return self.text
-
     class Meta:
         # as an abstract base class, Django won't create separate database tables for Question and
         # its subclasses -- instead all of the subclasses will just get these fields
@@ -112,6 +109,9 @@ class DocumentQuestion(Question):
         related_name='questions'
     )
 
+    def __str__(self):
+        return self.text
+
 
 class SegmentQuestion(Question):
     """
@@ -122,6 +122,9 @@ class SegmentQuestion(Question):
         on_delete=models.CASCADE,
         related_name='questions'
     )
+
+    def __str__(self):
+        return f'Segment {self.segment.sequence} - {self.text}'
 
 
 class StudentReadingData(models.Model):

--- a/backend/apps/readings/serializers.py
+++ b/backend/apps/readings/serializers.py
@@ -21,7 +21,7 @@ class DocumentQuestionResponseSerializer(serializers.ModelSerializer):
     Serializes a Student's response to a given document-level question
     """
     id = serializers.ModelField(model_field=DocumentQuestionResponse()._meta.get_field('id'))
-    evidence = serializers.ListField(child=serializers.CharField())
+    evidence = serializers.ListField(child=serializers.CharField(), required=False)
 
     class Meta:
         model = DocumentQuestionResponse
@@ -88,7 +88,7 @@ class SegmentQuestionResponseSerializer(serializers.ModelSerializer):
     Serializes a response provided to a question from a segment
     """
     id = serializers.ModelField(model_field=SegmentQuestionResponse()._meta.get_field('id'))
-    evidence = serializers.ListField(child=serializers.CharField())
+    evidence = serializers.ListField(child=serializers.CharField(), required=False)
 
     class Meta:
         model = SegmentQuestionResponse
@@ -172,15 +172,17 @@ class StudentReadingDataSerializer(serializers.ModelSerializer):
             segment_question_responses = this_segment_data.pop('segment_responses')
             for response in segment_question_responses:
                 question_id = response.pop('id')
-                evidence_list = response.pop('evidence')
-                evidence = json.dumps(evidence_list)
                 question = SegmentQuestion.objects.get(pk=question_id)
-                SegmentQuestionResponse.objects.create(
+                response = SegmentQuestionResponse.objects.create(
                     student_segment_data=segment_data,
                     question=question,
-                    evidence=evidence,
                     **response,
                 )
+                if 'evidence' in data:
+                    evidence_list = data.pop('evidence')
+                    evidence_json = json.dumps(evidence_list)
+                    response.evidence = evidence_json
+                    response.save()
 
         return reading_data
 

--- a/backend/apps/readings/serializers.py
+++ b/backend/apps/readings/serializers.py
@@ -178,8 +178,8 @@ class StudentReadingDataSerializer(serializers.ModelSerializer):
                     question=question,
                     **response,
                 )
-                if 'evidence' in data:
-                    evidence_list = data.pop('evidence')
+                if 'evidence' in this_segment_data:
+                    evidence_list = this_segment_data.pop('evidence')
                     evidence_json = json.dumps(evidence_list)
                     response.evidence = evidence_json
                     response.save()

--- a/backend/apps/readings/views.py
+++ b/backend/apps/readings/views.py
@@ -46,9 +46,16 @@ def add_response(request):
     reading_data_id = data.get('reading_data_id')
     reading_data = StudentReadingData.objects.get(pk=reading_data_id)
     serializer = StudentReadingDataSerializer(instance=reading_data, data=data)
-    serializer.is_valid()
-    serializer.save()
-    return Response(serializer.data)
+    is_valid = serializer.is_valid()
+
+    if is_valid:
+        serializer.save()
+        return Response(serializer.data)
+    else:
+        # NOTE(ra) -- This is for debugging -- this really needs proper error handling
+        print(serializer.errors)
+        return Response({})
+
 
 
 @api_view(['GET'])


### PR DESCRIPTION
To simplify the codebase, removes jumping, since we weren't using it.

This has a regression, sort of -- navigating to past segments now _doesn't_ repopulate from existing data. BUT the way we were doing it before was not robust to out of order segments, so we need to rewrite it anyway. That's up next.