### PR TITLE
Factor out description_has_relevant_words

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -71,7 +71,7 @@ disable=
     consider-using-get,
     chained-comparison,
     trailing-newlines,  # no big deal
-    too-many-lines  # RYAAN -- are you sure on this?
+    too-many-lines
 
 
 [REPORTS]

--- a/backend/apps/readings/analysis.py
+++ b/backend/apps/readings/analysis.py
@@ -6,6 +6,7 @@ Analysis.py - analyses for dhmit/rereading wired into the webapp
 import statistics
 
 from .models import StudentReadingData, StudentSegmentData, SegmentQuestionResponse
+from .analysis_helpers import string_contains_words
 
 
 class RereadingAnalysis:
@@ -92,30 +93,6 @@ class RereadingAnalysis:
 
         return len(student_names)
 
-
-    @staticmethod
-    def description_has_relevant_words(story_meaning_description, relevant_words):
-        """
-        Determine if the user's description contains a word relevant to the story's meaning
-        :param story_meaning_description: The user's response
-        :param relevant_words: a list of words which show an understanding of the story's meaning
-        :return True if the description contains one of the relevant words or relevant_words is
-        empty. False otherwise
-        """
-        if not relevant_words:
-            return True
-
-        lowercase_relevant_words = []
-        for word in relevant_words:
-            lowercase_relevant_words.append(word.lower())
-
-        words_used_in_description = story_meaning_description.lower().split(" ")
-
-        for word in lowercase_relevant_words:
-            if word.lower() in words_used_in_description:
-                return True
-        return False
-
     def percent_using_relevant_words_by_question(self):
         """
         Return a list of tuples with (question, percent), for each of the questions in the
@@ -141,7 +118,7 @@ class RereadingAnalysis:
             question = segment.question
             if question not in question_count_map:
                 question_count_map[question] = 0
-            if RereadingAnalysis.description_has_relevant_words(segment.response, relevant_words):
+            if string_contains_words(segment.response, relevant_words):
                 question_count_map[question] += 1
 
         total_student_count = len(self.readings)

--- a/backend/apps/readings/analysis_helpers.py
+++ b/backend/apps/readings/analysis_helpers.py
@@ -111,14 +111,7 @@ def remove_outliers(data):
 
 
 def string_contains_words(input_string, target_words):
-    """
-
-    Determine if the user's description contains a word relevant to the story's meaning
-    :param input_string: The user's three word description of the story
-    :param target_words: a list of words which show an understanding of the story's meaning
-    :return True if the description contains one of the relevant words or relevant_words is
-    empty. False otherwise
-    """
+    """ Checks if a given input_string contains any of the words in the list of target_words """
     if not target_words:
         return True
 

--- a/backend/apps/readings/analysis_helpers.py
+++ b/backend/apps/readings/analysis_helpers.py
@@ -109,3 +109,23 @@ def remove_outliers(data):
 
     return data_no_outliers
 
+
+def string_contains_words(input_string, target_words):
+    """
+
+    Determine if the user's description contains a word relevant to the story's meaning
+    :param input_string: The user's three word description of the story
+    :param target_words: a list of words which show an understanding of the story's meaning
+    :return True if the description contains one of the relevant words or relevant_words is
+    empty. False otherwise
+    """
+    if not target_words:
+        return True
+
+    input_string_lowercase = input_string.lower()
+
+    for word in target_words:
+        if word.lower() in input_string_lowercase:
+            return True
+
+    return False

--- a/backend/apps/readings/proto_analysis.py
+++ b/backend/apps/readings/proto_analysis.py
@@ -9,6 +9,7 @@ from collections import Counter
 from .analysis_helpers import (
     get_sentiments,
     remove_outliers,
+    string_contains_words,
 )
 from .models import StudentResponsePrototype, ContextPrototype
 
@@ -292,29 +293,6 @@ class PrototypeRereadingAnalysis:
         return len(unique_students)
 
     @staticmethod
-    def description_has_relevant_words(story_meaning_description, relevant_words):
-        """
-        Determine if the user's description contains a word relevant to the story's meaning
-        :param story_meaning_description: The user's three word description of the story
-        :param relevant_words: a list of words which show an understanding of the story's meaning
-        :return True if the description contains one of the relevant words or relevant_words is
-        empty. False otherwise
-        """
-        if not relevant_words:
-            return True
-
-        lowercase_relevant_words = []
-        for word in relevant_words:
-            lowercase_relevant_words.append(word.lower())
-
-        words_used_in_description = story_meaning_description.lower().split(" ")
-
-        for word in lowercase_relevant_words:
-            if word.lower() in words_used_in_description:
-                return True
-        return False
-
-    @staticmethod
     def transform_nested_dict_to_list(nested_dict):
         """
         Transforms a nested dictionary data structure into a flat array of tuples in the form
@@ -349,9 +327,7 @@ class PrototypeRereadingAnalysis:
             if context not in question_context_count_map[question]:
                 question_context_count_map[question][context] = 0
 
-            if PrototypeRereadingAnalysis.description_has_relevant_words(
-                    row.response,
-                    relevant_words):
+            if string_contains_words(row.response, relevant_words):
                 question_context_count_map[question][context] += 1
 
         flattened_data = \


### PR DESCRIPTION
Factors out `description_has_relevant_words` that was duplicated in the analysis and proto_analysis modules.
- Moves it out into analysis_helpers
- Gives it a more generic name (`string_contains_words`) because it's more general than the documentation and name implied